### PR TITLE
fix #20: Takes into account dependencies specifically added for the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
       <version>3.1.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.9.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>

--- a/src/main/java/com/github/johnpoth/jshell/JShellMojo.java
+++ b/src/main/java/com/github/johnpoth/jshell/JShellMojo.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -43,6 +44,9 @@ public class JShellMojo extends AbstractMojo
 
     @Parameter(defaultValue = "${project.testClasspathElements}", property = "trcp", required = true)
     private List<String> testClasspathElements;
+
+    @Parameter(property = "plugin.artifacts", required = true, readonly = true)
+    private List<Artifact> pluginArtifacts;
 
     @Parameter(defaultValue = "false", property = "testClasspath")
     private boolean testClasspath;
@@ -92,15 +96,22 @@ public class JShellMojo extends AbstractMojo
     }
 
     private String buildClasspath() {
+        final List<String> classpathElements = new ArrayList<>();
         if (testClasspath) {
-            testClasspathElements = filterClasspath(testClasspathElements);
-            return testClasspathElements.stream()
-                    .reduce("", (a, b) -> a + File.pathSeparator + b);
+            classpathElements.addAll(filterClasspath(testClasspathElements));
         } else {
-            runtimeClasspathElements = filterClasspath(runtimeClasspathElements);
-            return filterClasspath(runtimeClasspathElements).stream()
-                    .reduce("", (a, b) -> a + File.pathSeparator  + b);
+            classpathElements.addAll(filterClasspath(runtimeClasspathElements));
         }
+
+        if (!pluginArtifacts.isEmpty()) {
+            classpathElements.addAll(
+                    pluginArtifacts.stream()
+                            .map(artifact -> artifact.getFile().getAbsolutePath())
+                            .collect(Collectors.toList())
+            );
+        }
+        return filterClasspath(classpathElements).stream()
+                .reduce("", (a, b) -> a + File.pathSeparator + b);
     }
 
     private List<String> filterClasspath(List<String> cp) {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module com.github.johnpoth.jshell {
    /**not modules yet*/
    requires maven.plugin.api;
    requires maven.plugin.annotations;
+   requires maven.artifact;
 
    exports com.github.johnpoth.jshell;
 


### PR DESCRIPTION
Add specific dependencies added to plugins, for example via:

```
<plugin>
	<groupId>com.github.johnpoth</groupId>
	<artifactId>jshell-maven-plugin</artifactId>
	<!-- ... -->
	<dependencies>
		<dependency>
			<groupId>com.acme</groupId>
			<artifactId>other-dependency</artifactId>
			<version>X.X.X</version>
		</dependency>
	</dependencies>
</plugin>
```