### PR TITLE
Feature/add metadata to jar file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .classpath
 .project
 .settings
+/.git-versioned-pom.xml

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+	<extension>
+		<groupId>me.qoomon</groupId>
+		<artifactId>maven-git-versioning-extension</artifactId>
+		<version>9.6.5</version>
+	</extension>
+</extensions>

--- a/.mvn/maven-git-versioning-extension.xml
+++ b/.mvn/maven-git-versioning-extension.xml
@@ -1,0 +1,22 @@
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://github.com/qoomon/maven-git-versioning-extension" xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration-7.0.0.xsd">
+	<refs>
+		<ref type="branch">
+			<pattern>.+</pattern>
+			<!--
+				Uncomment following line when implementing Maven CI Friendly Versions: https://maven.apache.org/maven-ci-friendly.html
+			<version>${ref}-SNAPSHOT</version>
+			-->
+			<version>${version}</version>
+		</ref>
+
+		<ref type="tag">
+			<pattern><![CDATA[^v?(?<version>\d+\.\d+\.\d+.*)$]]></pattern>
+			<version>${ref.version}</version>
+		</ref>
+	</refs>
+
+	<!-- optional fallback configuration in case of no matching ref configuration-->
+	<rev>
+		<version>${commit}</version>
+	</rev>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
     </distributionManagement>
 
     <properties>
+        <!-- Configuring for Reproducible Builds (cf. https://maven.apache.org/guides/mini/guide-reproducible-builds.html) -->
+        <!--suppress UnresolvedMavenProperty -->
+        <project.build.outputTimestamp>${git.commit.timestamp.datetime}</project.build.outputTimestamp>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <Implementation-SCM-Revision-Number>${git.commit}</Implementation-SCM-Revision-Number>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <Implementation-SCM-Revision-Date>${git.commit.timestamp.datetime}</Implementation-SCM-Revision-Date>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <Implementation-Full-Version>${project.version}-${git.commit}</Implementation-Full-Version>
+                            <Java-Version>${java.version}</Java-Version>
+                            <Java-Vendor>${java.vendor}</Java-Vendor>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/github/johnpoth/jshell/JShellMojo.java
+++ b/src/main/java/com/github/johnpoth/jshell/JShellMojo.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,14 @@
  * limitations under the License.
  */
 package com.github.johnpoth.jshell;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import javax.tools.Tool;
 import java.io.File;
@@ -26,18 +34,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
 
 
-@Mojo( name = "run", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.TEST, requiresDependencyCollection = ResolutionScope.TEST )
-public class JShellMojo extends AbstractMojo
-{
+@Mojo(name = "run", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.TEST, requiresDependencyCollection = ResolutionScope.TEST)
+public class JShellMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project.runtimeClasspathElements}", property = "rcp", required = true)
     private List<String> runtimeClasspathElements;
@@ -121,12 +121,15 @@ public class JShellMojo extends AbstractMojo
         return cp.stream()
                 .filter(s -> {
                     Path path = Paths.get(s);
-                    if (Files.notExists(path)){
-                        getLog().warn("Removing: " + s +" from the classpath." + System.lineSeparator() +
-                                "If this is unexpected, please make sure you correctly build the project beforehand by invoking the correct Maven build phase (usually `install`, `test-compile` or `compile`). For example:" + System.lineSeparator() +
-                                "mvn test-compile com.github.johnpoth:jshell-maven-plugin:1.3:run" + System.lineSeparator() +
-                                "For more information visit https://github.com/johnpoth/jshell-maven-plugin"
-                        );
+                    if (Files.notExists(path)) {
+                        getLog().warn(String.format(
+                                "Removing: %s from the classpath.%n" +
+                                        "If this is unexpected, please make sure you correctly build the project beforehand by invoking the correct Maven build phase (usually `install`, `test-compile` or `compile`). For example:%n" +
+                                        "mvn test-compile com.github.johnpoth:jshell-maven-plugin:%s:run%n" +
+                                        "For more information visit https://github.com/johnpoth/jshell-maven-plugin",
+                                s,
+                                "1.3"
+                        ));
                         return false;
                     }
                     if (Files.isDirectory(path)) {
@@ -135,7 +138,7 @@ public class JShellMojo extends AbstractMojo
                     if (s.endsWith(".jar")) {
                         return true;
                     }
-                    getLog().debug("Removing: " + s +" from the classpath because it is unsupported in JShell.");
+                    getLog().debug("Removing: " + s + " from the classpath because it is unsupported in JShell.");
                     return false;
                 }).collect(Collectors.toList());
     }
@@ -145,19 +148,19 @@ public class JShellMojo extends AbstractMojo
         if (useProjectClasspath) {
             args.add("--class-path");
             args.add(cp);
-        } else if (classpath != null ){
+        } else if (classpath != null) {
             args.add("--class-path");
             args.add(classpath);
         }
-        if (modulepath != null){
+        if (modulepath != null) {
             args.add("--module-path");
             args.add(modulepath);
         }
-        if (addModules!= null){
+        if (addModules != null) {
             args.add("--add-modules");
             args.add(addModules);
         }
-        if (addExports!= null){
+        if (addExports != null) {
             args.add("--add-exports");
             args.add(addExports);
         }

--- a/src/main/java/com/github/johnpoth/jshell/JShellMojo.java
+++ b/src/main/java/com/github/johnpoth/jshell/JShellMojo.java
@@ -35,6 +35,8 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
+import static java.util.Optional.ofNullable;
+
 
 @Mojo(name = "run", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.TEST, requiresDependencyCollection = ResolutionScope.TEST)
 public class JShellMojo extends AbstractMojo {
@@ -128,7 +130,7 @@ public class JShellMojo extends AbstractMojo {
                                         "mvn test-compile com.github.johnpoth:jshell-maven-plugin:%s:run%n" +
                                         "For more information visit https://github.com/johnpoth/jshell-maven-plugin",
                                 s,
-                                "1.3"
+                                ofNullable(this.getClass().getPackage().getImplementationVersion()).orElse("RELEASE")
                         ));
                         return false;
                     }


### PR DESCRIPTION
Add metadata to strengthen the traceability of each artifact built.

Example of information added in the `META-INF/METADATA.MF` file inside the built JAR file:

```
Specification-Title: jshell-maven-plugin Maven Plugin
Specification-Version: 1.5
Implementation-Title: jshell-maven-plugin Maven Plugin
Implementation-Version: 1.5-SNAPSHOT
Implementation-Full-Version: 1.5-SNAPSHOT-27266ae4bf49e4146a6967fd84ce39d55d2ad046
Implementation-SCM-Revision-Date: 2023-08-05T14:06:27Z
Implementation-SCM-Revision-Number: 27266ae4bf49e4146a6967fd84ce39d55d2ad046
```

Also, Maven build is now reproducible. To check 
```sh
mvn clean install && mvn clean verify artifact:compare
```
Additional Information:
* [Maven Guide - Configuring for Reproducible Builds](https://maven.apache.org/guides/mini/guide-reproducible-builds.html)